### PR TITLE
Configured logging

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -6,7 +6,7 @@
         </encoder>
     </appender>
     <appender name="SAVE-TO-FILE" class="ch.qos.logback.core.FileAppender">
-        <file>logs/application.log</file>
+        <file>car-microservices/logs/inventory-service.log</file>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <Pattern>%d{dd-MM-yyyy HH:mm:ss.SSS} [%thread] %-5level %logger{36}.%M - %msg%n</Pattern>
         </encoder>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{dd-MM-yyyy HH:mm:ss.SSS} [%thread] %-5level %logger{36}.%M - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <appender name="SAVE-TO-FILE" class="ch.qos.logback.core.FileAppender">
+        <file>logs/application.log</file>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <Pattern>%d{dd-MM-yyyy HH:mm:ss.SSS} [%thread] %-5level %logger{36}.%M - %msg%n</Pattern>
+        </encoder>
+    </appender>
+    <logger name="com.gznznzjsn.inventoryservice" additivity="false" level="info">
+        <appender-ref ref="SAVE-TO-FILE"/>
+        <appender-ref ref="STDOUT"/>
+    </logger>
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds logging configuration to the inventory service.

### Detailed summary
- Added `logback-spring.xml` file to `src/main/resources` directory
- Configured two appenders: `STDOUT` and `SAVE-TO-FILE`
- `STDOUT` appender logs to console
- `SAVE-TO-FILE` appender logs to a file located at `car-microservices/logs/inventory-service.log`
- Both appenders use the same log pattern: `%d{dd-MM-yyyy HH:mm:ss.SSS} [%thread] %-5level %logger{36}.%M - %msg%n`
- Added a logger with name `com.gznznzjsn.inventoryservice` and level `info`
- The logger references both appenders
- Added a root logger that references the `STDOUT` appender

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->